### PR TITLE
Core: Restore branding preferences when Clear all.

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -3285,17 +3285,9 @@ void Application::LoadParameters()
         if (_pcUserParamMngr->LoadOrCreateDocument() && mConfig["Verbose"] != "Strict") {
             // The user parameter file doesn't exist. When an alternative parameter file is offered
             // this will be used.
-            const auto it = mConfig.find("UserParameterTemplate");
-            if (it != mConfig.end()) {
-                QString path = QString::fromUtf8(it->second.c_str());
-                if (QDir(path).isRelative()) {
-                    const QString home = QString::fromUtf8(mConfig["AppHomePath"].c_str());
-                    path = QFileInfo(QDir(home), path).absoluteFilePath();
-                }
-                const QFileInfo fi(path);
-                if (fi.exists()) {
-                    _pcUserParamMngr->LoadDocument(path.toUtf8().constData());
-                }
+            const char* userParamPath = getUserParameterTemplatePath();
+            if (userParamPath) {
+                _pcUserParamMngr->LoadDocument(userParamPath);
             }
 
             // Configuration file optional when using as Python module
@@ -3314,6 +3306,24 @@ void Application::LoadParameters()
                               e.what(), mConfig["UserParameter"].c_str());
         _pcUserParamMngr->CreateDocument();
     }
+}
+
+const char* Application::getUserParameterTemplatePath()
+{
+    const auto it = mConfig.find("UserParameterTemplate");
+    if (it != mConfig.end()) {
+        QString path = QString::fromUtf8(it->second.c_str());
+        if (QDir(path).isRelative()) {
+            const QString home = QString::fromUtf8(mConfig["AppHomePath"].c_str());
+            path = QFileInfo(QDir(home), path).absoluteFilePath();
+        }
+        const QFileInfo fi(path);
+        if (fi.exists()) {
+            const char* templatePath = path.toUtf8().constData();
+            return templatePath;
+        }
+    }
+    return nullptr;
 }
 
 #if defined(_MSC_VER) && BOOST_VERSION < 108200

--- a/src/App/Application.h
+++ b/src/App/Application.h
@@ -895,6 +895,7 @@ public:
     bool hasLinksTo(const DocumentObject *obj) const;
     /// @}
 
+    static const char* getUserParameterTemplatePath();
 
     friend class App::Document;
 

--- a/src/Gui/Dialogs/DlgPreferencesImp.cpp
+++ b/src/Gui/Dialogs/DlgPreferencesImp.cpp
@@ -831,6 +831,13 @@ void DlgPreferencesImp::restoreDefaults()
         ParameterManager* mgr = App::GetApplication().GetParameterSet("User parameter");
         mgr->Clear();
 
+        // Restore the default preferences template if any
+        const char* templatePath = App::Application::getUserParameterTemplatePath();
+        if (templatePath) {
+            mgr->LoadDocument(templatePath);
+            restartRequired = true;  // the reloaded are not applied.
+        }
+
         App::GetApplication()
             .GetParameterGroupByPath("User parameter:BaseApp/Preferences/General")
             ->SetBool("SaveUserParameter", saveParameter);


### PR DESCRIPTION
Restore branding preferences when Clear all.

Currently when you clean preferences, it does not re-apply the branding preferences. Hence breaking fork styles on clear.

This PR fixes that.